### PR TITLE
feat: add cerberus region

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Have you finished an Araxxor task before heading straight into ToB and realising at Xarpus that your Scythe's attack style is on crush? Then this plugin is for you!
 
-The overlay hides automatically when at Araxxor/Nightmare/Hueycoatl.
+The overlay hides automatically when at Araxxor/Nightmare/Hueycoatl/Cerberus.

--- a/src/main/java/com/scythecrushwarning/AllowedRegions.java
+++ b/src/main/java/com/scythecrushwarning/AllowedRegions.java
@@ -50,6 +50,11 @@ class AllowedRegions
 		{
 			allowedRegions.addAll(HueycoatlRegion.getAllRegions());
 		}
+
+		if (config.ignoreCerberus())
+		{
+			allowedRegions.addAll(CerberusRegion.getAllRegions());
+		}
 	}
 
 	public boolean regionChanged()

--- a/src/main/java/com/scythecrushwarning/CerberusRegion.java
+++ b/src/main/java/com/scythecrushwarning/CerberusRegion.java
@@ -1,0 +1,35 @@
+package com.scythecrushwarning;
+
+import java.util.ArrayList;
+import lombok.Getter;
+
+@Getter
+public enum CerberusRegion
+{
+	CERBERUS(5139),
+	CERBERUS_NORTH(5140),
+	CERBERUS_EAST(5395),
+	CERBERUS_WEST(4883);
+
+	private final int region;
+
+	private static final ArrayList<Integer> ALL_REGIONS = new ArrayList<>();
+
+	static
+	{
+		for (CerberusRegion e : values())
+		{
+			ALL_REGIONS.add(e.region);
+		}
+	}
+
+	CerberusRegion(int region)
+	{
+		this.region = region;
+	}
+
+	public static ArrayList<Integer> getAllRegions()
+	{
+		return ALL_REGIONS;
+	}
+}

--- a/src/main/java/com/scythecrushwarning/ScytheCrushWarningConfig.java
+++ b/src/main/java/com/scythecrushwarning/ScytheCrushWarningConfig.java
@@ -27,6 +27,12 @@ public interface ScytheCrushWarningConfig extends Config
 		return true;
 	}
 
+	@ConfigItem(keyName = "ignoreCerberus", name = "Ignore at Cerberus", description = "Do not show warning at Cerberus")
+	default boolean ignoreCerberus()
+	{
+		return true;
+	}
+
 	@Alpha
 	@ConfigItem(keyName = "overlayColor", name = "Overlay Color", description = "Overlay Background Color")
 	default Color overlayColor()

--- a/src/main/java/com/scythecrushwarning/ScytheCrushWarningPlugin.java
+++ b/src/main/java/com/scythecrushwarning/ScytheCrushWarningPlugin.java
@@ -29,7 +29,7 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 @Slf4j
-@PluginDescriptor(name = "Scythe Crush Warning", description = "Show a warning if your Scythe is on crush", tags = {"scythe", "crush", "araxxor", "nightmare", "hueycoatl"})
+@PluginDescriptor(name = "Scythe Crush Warning", description = "Show a warning if your Scythe is on crush", tags = {"scythe", "crush", "araxxor", "nightmare", "hueycoatl, cerberus"})
 public class ScytheCrushWarningPlugin extends Plugin
 {
 	public static final String CONFIG_GROUP = "scythecrushwarning";


### PR DESCRIPTION
Scythe on crush with inquisitor is a setup used at Cerberus. Would be nice to be able to ignore this warning.